### PR TITLE
Add working rust raffler

### DIFF
--- a/aochagavia-rust/Cargo.lock
+++ b/aochagavia-rust/Cargo.lock
@@ -1,0 +1,41 @@
+[root]
+name = "raffler"
+version = "0.1.0"
+dependencies = [
+ "rand 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "advapi32-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+

--- a/aochagavia-rust/Cargo.toml
+++ b/aochagavia-rust/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "raffler"
+version = "0.1.0"
+authors = ["Adolfo Ochagavía <aochagavia92@gmail.com>"]
+
+[dependencies]
+rand = "0.3.13"

--- a/aochagavia-rust/readme.md
+++ b/aochagavia-rust/readme.md
@@ -1,0 +1,4 @@
+Rust Raffler
+============
+
+Usage: `cargo run --release <text_file_path>`

--- a/aochagavia-rust/src/main.rs
+++ b/aochagavia-rust/src/main.rs
@@ -1,0 +1,25 @@
+extern crate rand;
+
+use rand::Rng;
+use std::env;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+
+fn main() {
+    let args: Vec<_> = env::args().collect();
+
+    if args.len() < 2 {
+        println!("Insufficient arguments given");
+        return;
+    }
+
+    let file = File::open(&args[1]).expect("Failed to open file");
+    let names = BufReader::new(file).lines()
+                                    .collect::<Result<Vec<_>, _>>()
+                                    .expect("Failed to read lines");
+
+    let chosen_one = rand::thread_rng().choose(&names)
+                                       .expect("The list of names is empty");
+
+    println!("The winner is: {}", chosen_one);
+}


### PR DESCRIPTION
@lucasvanlierop Maybe it would be useful to use [this docker image](https://hub.docker.com/r/jimmycuadra/rust/). That way you don't need an extra install script.