### PR TITLE
Elixir raffler – Remove unnecessary random seed

### DIFF
--- a/rjkip-elixir/raffler.exs
+++ b/rjkip-elixir/raffler.exs
@@ -1,2 +1,1 @@
-:random.seed :erlang.now
 IO.puts File.stream!(System.argv) |> Enum.shuffle |> Enum.at(0)


### PR DESCRIPTION
Remove unnecessary random seed, as documented by Elixir:

    http://elixir-lang.org/docs/stable/elixir/Enum.html#shuffle/1

This caused an Erlang warning "Deprecated BIF":

![image](https://cloud.githubusercontent.com/assets/1734555/12810524/089f2c20-cb27-11e5-9c15-db16ad8d15d6.png)
