### PR TITLE
Speedup shawnmccool-scala

### DIFF
--- a/shawnmccool-scala/Dockerfile
+++ b/shawnmccool-scala/Dockerfile
@@ -22,6 +22,7 @@ RUN wget http://www.scala-lang.org/files/archive/scala-2.11.6.deb
 RUN dpkg -i scala-2.11.6.deb
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y scala
+RUN ./build.sh
 
 # Run raffler
 CMD ["/var/app/run.sh"]

--- a/shawnmccool-scala/Raffler.scala
+++ b/shawnmccool-scala/Raffler.scala
@@ -1,15 +1,19 @@
 import scala.util.Random
 import scala.io.Source
 
-def chooseWinner(contestants: List[String]): Unit = {
-    if ( ! contestants.isEmpty) {
-      println(contestants.head)
+object Raffler {
+    def main(args: Array[String]) {
+        try {
+          val contestants = Random.shuffle(Source.fromFile(args(0)).getLines()).toList
+          chooseWinner(contestants)
+        } catch {
+          case _: Throwable => println("Could not load the file.")
+        }
     }
-}
 
-try {
-  val contestants = Random.shuffle(Source.fromFile(args(0)).getLines()).toList
-  chooseWinner(contestants)
-} catch {
-  case _: Throwable => println("Could not load the file.")
+    def chooseWinner(contestants: List[String]): Unit = {
+        if ( ! contestants.isEmpty) {
+          println(contestants.head)
+        }
+    }
 }

--- a/shawnmccool-scala/build.sh
+++ b/shawnmccool-scala/build.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+scalac -cp . Raffler.scala

--- a/shawnmccool-scala/run.sh
+++ b/shawnmccool-scala/run.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-scala Raffler.scala ../names/current
+scala -cp . Raffler /var/names/current


### PR DESCRIPTION
Speedup scala raffler by compiling the scala code when the docker
container is built and then run the compiled code when the container
is run, instead of compiling the code every time the container is
run.