### PR TITLE
Remove trailing newline from names file used in testing

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -2,7 +2,7 @@
 
 # Provide likely winner.
 mkdir -p names
-echo "Reinier Kip" > names/current
+echo -n "Reinier Kip" > names/current
 
 # Win. Every time.
 dockerfiles=$(ls */Dockerfile)


### PR DESCRIPTION
The brainfuck raffler sometimes picks the trailing newline as the winner. Since I am unable to modify that brainfuck of a brainfuck script, let's just accept that some rafflers may pick the newline. Just raffle again.