### PR TITLE
Fixed the glitch dockerized version

### DIFF
--- a/scato-glitch/Dockerfile
+++ b/scato-glitch/Dockerfile
@@ -12,4 +12,4 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin -
 # make sure that when we run the container using the standard of /var/names filled with the names, it can be read from the /var/app glitch app
 RUN ln -s /var/names /var/app/names
 
-CMD ["php", "/var/app/vendor/bin/glitch", "raffler.g", "names"]
+CMD ["php", "/var/app/vendor/bin/glitch", "raffler.g", "names/current"]

--- a/scato-glitch/Dockerfile
+++ b/scato-glitch/Dockerfile
@@ -1,0 +1,15 @@
+FROM php:7-alpine
+MAINTAINER robin@kingsquare.nl
+
+# Create working dir
+RUN mkdir -p /var/app
+COPY . /var/app
+WORKDIR /var/app
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
+    composer install --prefer-dist --no-dev -o
+
+# make sure that when we run the container using the standard of /var/names filled with the names, it can be read from the /var/app glitch app
+RUN ln -s /var/names /var/app/names
+
+CMD ["php", "/var/app/vendor/bin/glitch", "raffler.g", "names"]


### PR DESCRIPTION
It might be a bit ugly, but due to the comment from @scato that the code cannot look outside the `/var/app` root we pre-symlink the names file during build to it so when running it like:

 ```
 docker run -v $(the-names-location-on-the-host):/var/names scato-glitch
 ```
 everything should work :)

This fixes the issue #94 