### PR TITLE
Updated build output

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 
-dockerfiles=$(ls */Dockerfile)
+echo "Using docker(`docker version -f "{{.Server.Version}} / {{.Client.Version}}"`) to build containers..."
+
+if [[ "$1" && "$1" != "--rebuild" ]]; then
+    dockerfiles=("$1/Dockerfile")
+else
+    dockerfiles=$(ls */Dockerfile)
+fi
+
 for file in $dockerfiles; do
 	dir=${file:0:-11}
 	container=${dir/-/_}"_raffler"
 	if [[ $1 == "--rebuild" || $(docker images | awk '{print $1}' | grep -c '^'"$container"'$') -eq 0 ]]; then
 		echo "Building $container from $dir"
-		docker build -t "$container" "$dir"
+		docker build -q -t "$container" "$dir"
 		if [[ $? != 0 ]]; then
 			echo "Build failed!"
 			exit 1


### PR DESCRIPTION
Include the used docker version in the build output... (this might explain version discrepancies in the future)

I've also added the suppression of the actual intermediate steps during build since IMHO they clutter the Travis logs too much ;)