### PR TITLE
Zsh 2.0

### DIFF
--- a/basbl-zsh/Dockerfile
+++ b/basbl-zsh/Dockerfile
@@ -1,15 +1,12 @@
-FROM ubuntu:15.10
-MAINTAINER lucas@vanlierop.org
-ENV LANG C.UTF-8
+FROM alpine:3.3
+MAINTAINER robin@kingsquare.nl
 
-# Install Z shell
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y zsh
+RUN apk add --no-cache zsh
 
 # Create working dir
 RUN mkdir -p /var/app
-COPY . /var/app
+COPY raffler /var/app
 WORKDIR /var/app
 
 # Run raffler
-CMD ["/var/app/run.sh"]
+CMD ["zsh", "./raffler", "/var/names/current"]

--- a/remyhonig-elisp/Dockerfile
+++ b/remyhonig-elisp/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.4
-MAINTAINER robin@kingsquare.org
+MAINTAINER robin@kingsquare.nl
 
 RUN apk add emacs --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted
 

--- a/rjkip-bash/Dockerfile
+++ b/rjkip-bash/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:jessie
-MAINTAINER robin@kingsquare.org
+MAINTAINER robin@kingsquare.nl
 
 # Create working dir
 RUN mkdir -p /var/app


### PR DESCRIPTION
Instead of using a larger image, this now uses a smaller image which in turn will speed up builds and such... 
(new version is only 12mb)