### PR TITLE
Bashed it out

### DIFF
--- a/jaytaph-bash/Dockerfile
+++ b/jaytaph-bash/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.4
+MAINTAINER robin@kingsquare.nl
+
+RUN apk add --no-cache bash
+
+RUN mkdir -p /var/app
+WORKDIR /var/app
+COPY raffle.sh /var/app
+
+CMD ["bash", "/var/app/raffle.sh", "/var/names/current"]

--- a/jaytaph-bash/README.md
+++ b/jaytaph-bash/README.md
@@ -4,4 +4,4 @@ Display a winner in your commandline prompt. Because you need a raffle winner, a
 Make sure your raffle.txt is in the root directory.
 Run on bash with:
 
-      source raffle.sh
+      source raffle.sh ../example_names

--- a/jaytaph-bash/raffle.sh
+++ b/jaytaph-bash/raffle.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-PROMPT_COMMAND='echo -e "\033[0;32mThe raffle-winner:\033[0m \033[1;33m$(cat /raffle.txt | sort -R | head -n 1)\033[0m"'
+echo -e "\033[0;32mThe raffle-winner:\033[0m \033[1;33m$(cat $1 | shuf | head -n 1)\033[0m"
 

--- a/jaytaph-bash/raffle.txt
+++ b/jaytaph-bash/raffle.txt
@@ -1,3 +1,0 @@
-curly
-larry
-moe


### PR DESCRIPTION
Had to alter the original shell version not to include it into the prompt, but just echo the result. Also removed the `sort -R` in favor of _real_ shuffling of the lines using `shuf`

Also removed the hardcoded raffle.txt since its now injected as a paramter.
Updated the docs to reflect...

Since this changes the original code alot... one might say this is a new bash rafffler...  your call i guess ;)