### PR TITLE
Add raffler in D using chained UFCS

### DIFF
--- a/arothuis-dlang/Dockerfile
+++ b/arothuis-dlang/Dockerfile
@@ -1,0 +1,10 @@
+FROM dlanguage/dmd
+MAINTAINER alex.rothuis@gmail.com
+
+RUN mkdir -p /var/app
+COPY . /var/app
+WORKDIR /var/app
+
+RUN dmd raffler.d
+
+CMD ["/var/app/raffler", "/var/names/current"]

--- a/arothuis-dlang/raffler.d
+++ b/arothuis-dlang/raffler.d
@@ -6,6 +6,12 @@ import core.stdc.stdlib;
 
 void main(string[] args)
 {
+    if (args.length < 2 || args[1] == "help") {
+        writeln("[ERROR] No file path found.");
+        writeln("   Usage: raffler <FILE_PATH>");
+        exit(1);
+    }
+
     try {
         args[1].readText.strip.splitLines.choice.writeln;
     } catch (FileException e) {

--- a/arothuis-dlang/raffler.d
+++ b/arothuis-dlang/raffler.d
@@ -1,0 +1,15 @@
+import std.file;
+import std.random;
+import std.stdio;
+import std.string;
+import core.stdc.stdlib;
+
+void main(string[] args)
+{
+    try {
+        args[1].readText.strip.splitLines.choice.writeln;
+    } catch (FileException e) {
+        writeln("[ERROR] Could not read file. ", e.msg);
+        exit(1);
+    }
+}


### PR DESCRIPTION
D is an extensive language, but it can be simple.

[Uniform Function Call Syntax](https://tour.dlang.org/tour/en/gems/uniform-function-call-syntax-ufcs) allows for chaining functions in a neat, readable way. Whenever calling a function on a type, the compiler checks if the type has that method. If the type does not have said method, the compiler tries to apply a function that conforms to the signature using the type that is called upon as the first parameter and, if any, other arguments as remaining parameters.

Alternatively, your could add "import std.functional" and do one of the following functional looking one-liners:
-  `compose!(writeln, choice, splitLines, strip,readText)(args[1]);`
-  `pipe!(readText, strip, splitLines, choice, writeln)(args[1]);` (reverse order of compose)
