### PR TITLE
for bash rafflers: use the official bash image instead

### DIFF
--- a/jaytaph-bash/Dockerfile
+++ b/jaytaph-bash/Dockerfile
@@ -1,10 +1,5 @@
-FROM alpine:3.4
-MAINTAINER robin@kingsquare.nl
+FROM bash
 
-RUN apk add --no-cache bash
+COPY raffle.sh /
 
-RUN mkdir -p /var/app
-WORKDIR /var/app
-COPY raffle.sh /var/app
-
-CMD ["bash", "/var/app/raffle.sh", "/var/names.txt"]
+CMD ["bash", "/raffle.sh", "/var/names.txt"]

--- a/jaytaph-bash/Dockerfile
+++ b/jaytaph-bash/Dockerfile
@@ -1,4 +1,8 @@
-FROM bash
+FROM alpine
+
+RUN apk add --no-cache bash coreutils
+
+WORKDIR /
 
 COPY raffle.sh /
 

--- a/jaytaph-bash/raffle.sh
+++ b/jaytaph-bash/raffle.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo -e "\033[0;32mThe raffle-winner:\033[0m \033[1;33m$(cat $1 | shuf | head -n 1)\033[0m"
-

--- a/jaytaph-bash/raffle.sh
+++ b/jaytaph-bash/raffle.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-echo -e "\033[0;32mThe raffle-winner:\033[0m \033[1;33m$(cat $1 | shuf | head -n 1)\033[0m"
+echo -e "\033[0;32mThe raffle-winner:\033[0m \033[1;33m$(shuf $1 | head -n 1)\033[0m"

--- a/rjkip-bash/Dockerfile
+++ b/rjkip-bash/Dockerfile
@@ -1,10 +1,5 @@
-FROM debian:jessie
-MAINTAINER robin@kingsquare.nl
+FROM bash
 
-# Create working dir
-RUN mkdir -p /var/app
-COPY . /var/app
-WORKDIR /var/app
+COPY raffler /
 
-# Run raffler
-CMD ["/var/app/raffler", "/var/names.txt"]
+CMD ["bash", "/raffler", "/var/names.txt"]

--- a/rjkip-bash/raffler
+++ b/rjkip-bash/raffler
@@ -1,2 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 head -$((${RANDOM} % `wc -l < $1` + 1)) $1 | tail -1


### PR DESCRIPTION
> _**EDIT**_: I've pinpointed the issue to the busybox version of `shuf` (reported it [here](https://bugs.busybox.net/show_bug.cgi?id=9971)). Installing `coreutils` provides the default gnu `shuf` which does not seem to suffer from this peculiarity. Also removed a [useless use of `cat`](http://porkmail.org/era/unix/award.html#cat) instance.

---

Updated the bash images.

I also ran into something odd. The bash script of jaytaph will never return the first line as a winner when run inside a container (very peculiar). This could be considered discrimination or unfair bias perhaps?
 Note that this behavior already existed before I made my change(s) to the Dockerfile:

Example `names.txt`:
```
rob /code/rafflers/jaytaph-bash > cat names.txt
foo
bar
baz
```

Running the container:
```
rob /code/rafflers/jaytaph-bash > for i in {1..100}; \
  do docker run -it --rm -v $(pwd)/names.txt:/var/names.txt bash; \
done
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: bar
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: bar
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: bar
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: bar
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: bar
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: bar
The raffle-winner: baz
The raffle-winner: bar
The raffle-winner: bar
```

Same code directly on shell:
```
rob /code/rafflers/jaytaph-bash > for i in {1..100}; \
  do echo $(cat names.txt | shuf | head -n 1); \
done
foo
bar
foo
foo
foo
baz
foo
foo
bar
baz
foo
foo
foo
baz
foo
foo
bar
bar
bar
bar
baz
baz
bar
bar
bar
foo
baz
baz
baz
baz
foo
bar
bar
bar
foo
foo
baz
bar
bar
foo
baz
baz
foo
baz
foo
baz
foo
baz
baz
foo
baz
foo
baz
bar
foo
baz
foo
bar
baz
baz
bar
foo
baz
bar
bar
baz
bar
baz
foo
foo
bar
baz
baz
foo
baz
foo
foo
bar
foo
foo
bar
bar
baz
baz
baz
foo
bar
bar
foo
foo
baz
bar
bar
baz
foo
foo
bar
foo
bar
foo
```