### PR TITLE
Add dockerized Powershell raffler

### DIFF
--- a/jeroenheijmans-powershell/Dockerfile
+++ b/jeroenheijmans-powershell/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    apt-transport-https
+
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+RUN curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | tee /etc/apt/sources.list.d/microsoft.list
+
+RUN apt-get update && apt-get install -y \
+    powershell
+
+COPY raffle.ps1 /var/app/raffle.ps1
+
+WORKDIR /var/app
+
+CMD ["powershell", "raffle.ps1"]

--- a/jeroenheijmans-powershell/README.md
+++ b/jeroenheijmans-powershell/README.md
@@ -1,0 +1,11 @@
+# JeroenHeijmans-Powershell Raffler
+
+This raffler uses [PowerShell](https://github.com/PowerShell/PowerShell) on Linux in a Docker container to randomly pick a winner. Skips white lines.
+
+## Testing
+
+Run this in the root of the project to verify:
+
+```sh
+sudo make test RAFFLER=jeroenheijmans-powershell
+```

--- a/jeroenheijmans-powershell/raffle.ps1
+++ b/jeroenheijmans-powershell/raffle.ps1
@@ -1,0 +1,1 @@
+Get-Content /var/names.txt | Where-Object {$_ -ne ""} | Get-Random


### PR DESCRIPTION
Wait wut!? Powershell on Linux? No wai! Wai!

Verified with `sudo make test RAFFLER=jeroenheijmans-powershell`.