### PR TITLE
Add new C raffler with reservoir sampling

### DIFF
--- a/c-sjmulder/Dockerfile
+++ b/c-sjmulder/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.7
+RUN apk add --no-cache musl-dev
+RUN apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ tcc
+COPY raffler.c raffler.c
+RUN tcc raffler.c -o raffler
+CMD /raffler </var/names.txt

--- a/c-sjmulder/README
+++ b/c-sjmulder/README
@@ -1,0 +1,15 @@
+c-sjmulder
+
+Most rafflers here either
+ - read the entire file into memory, then operate on it, or
+ - do two passes over the file.
+
+This one does neither, instead it takes one pass using reservoir sampling
+at the cost of more rand() calls.
+
+To compile and use:
+
+    cc -o raffler raffler.c
+    ./raffler <names.txt
+
+By Sijmen J. Mulder <ik@sjmulder.nl>

--- a/c-sjmulder/raffler.c
+++ b/c-sjmulder/raffler.c
@@ -1,0 +1,36 @@
+#define _WITH_GETLINE
+
+#include <sys/time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <err.h>
+
+int
+main(void)
+{
+	struct timeval tv;
+	char *winner = NULL;
+	char *line = NULL;
+	size_t cap;
+	int n = 0;
+
+	gettimeofday(&tv, NULL);
+	srand((unsigned)tv.tv_usec);
+
+	while (getline(&line, &cap, stdin) != -1) {
+		if (!n || rand() % n == 0) {
+			free(winner);
+			winner = line;
+			line = NULL;
+		}
+		n += 1;
+	}
+
+	if (ferror(stdin))
+		err(1, "raffle");
+	if (!winner)
+		errx(1, "raffle: empty input");
+
+	fputs(winner, stdout);
+	return 0;
+}

--- a/c-sjmulder/raffler.c
+++ b/c-sjmulder/raffler.c
@@ -27,9 +27,9 @@ main(void)
 	}
 
 	if (ferror(stdin))
-		err(1, "raffle");
+		err(1, NULL);
 	if (!winner)
-		errx(1, "raffle: empty input");
+		errx(1, "empty input");
 
 	fputs(winner, stdout);
 	return 0;


### PR DESCRIPTION
Most rafflers here either

- read the entire file into memory, then operate on it, or
- do two passes over the file.

This one does neither, instead it takes one pass using reservoir sampling at the cost of more rand() calls.

To compile and use:

    cc -o raffler raffler.c
    ./raffler <names.txt