### PR TITLE
Here goes nothing!

### DIFF
--- a/io-ramondelafuente/Dockerfile
+++ b/io-ramondelafuente/Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:jessie
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LANG C.UTF-8
+
+RUN apt-get update
+RUN apt-get install -y wget
+RUN apt-get install -y unzip
+
+RUN mkdir -p /app
+
+WORKDIR /app
+RUN wget http://iobin.suspended-chord.info/linux/iobin-linux-x64-deb-current.zip 2>&1 && unzip iobin-linux-x64-deb-current.zip 2>&1 && dpkg -i /app/IoLanguage-2013.11.04-Linux-x64.deb
+
+COPY raffler.io /app/
+
+# Run raffler
+CMD ["io", "/app/raffler.io", "/var/names.txt"]

--- a/io-ramondelafuente/raffler.io
+++ b/io-ramondelafuente/raffler.io
@@ -1,0 +1,1 @@
+Random; File with(System args at(1)) openForReading readLines shuffle at(0) println


### PR DESCRIPTION
![I have no idea what I'm doing](https://media.giphy.com/media/xDQ3Oql1BN54c/giphy.gif)

This should be a raffler in the [IO language](http://iolanguage.org) with a working Docker image. But I can't actually test this through the makefile because I get `Makefile:6: *** missing separator.  Stop.`

So I tested the Docker image (that runs the raffler.io but has no /var/names.txt) and I tested the raffler.io (it works on my machine). I leave it to the project maintainers to confirm if it works when put together...

![test in production](https://i.imgflip.com/fuks6.jpg)